### PR TITLE
[Issue #3564] Enclose namesrvAddr in example of mqadmin tool by quotation marks

### DIFF
--- a/_docs/04-cli-admin-tool.md
+++ b/_docs/04-cli-admin-tool.md
@@ -74,7 +74,7 @@ As you see, the most commonly used commands are listed with a brief description.
      -h,--help                Print help
      -i,--interval <arg>      specify intervals numbers, it is in seconds
      -m,--moreStats           Print more stats
-     -n,--namesrvAddr <arg>   Name server address list, eg: 192.168.0.1:9876;192.168.0.2:9876
+     -n,--namesrvAddr <arg>   Name server address list, eg: '192.168.0.1:9876;192.168.0.2:9876'
 
 
 The help text lists possible options and interpretation of each option. 

--- a/_docs/14-rmq-deployment.md
+++ b/_docs/14-rmq-deployment.md
@@ -107,7 +107,7 @@ usage: mqadmin clusterList [-h] [-i <arg>] [-m] [-n <arg>]
  -h,--help                Print help
  -i,--interval <arg>      specify intervals numbers, it is in seconds
  -m,--moreStats           Print more stats
- -n,--namesrvAddr <arg>   Name server address list, eg: 192.168.0.1:9876;192.168.0.2:9876
+ -n,--namesrvAddr <arg>   Name server address list, eg: '192.168.0.1:9876;192.168.0.2:9876'
 ```
 
 ### Replication mode


### PR DESCRIPTION
## What is the purpose of the change

[#3564 ](https://github.com/apache/rocketmq/issues/3564)

## Brief changelog

add single quotes for namesrvAddr option example, to avoid command splits caused by semicolons

## Verifying this change
