### PR TITLE
Update 01quickstart.md

### DIFF
--- a/versioned_docs/version-5.0/02-quickStart/01quickstart.md
+++ b/versioned_docs/version-5.0/02-quickStart/01quickstart.md
@@ -53,7 +53,30 @@ The Name Server boot success...
 NameServer成功启动后，我们启动Broker和Proxy，5.x 版本下我们建议使用 Local 模式部署，即 Broker 和 Proxy 同进程部署。5.x 版本也支持 Broker 和 Proxy 分离部署以实现更灵活的集群能力。详情参考[部署教程](../05-deploymentOperations/01deploy.md)。
 
 ```shell
-### 先启动broker
+配置grpc端口
+
+vim conf/rmq-proxy.json
+
+```sh
+{
+  "rocketMQClusterName": "DefaultCluster",
+  "grpcServerPort" : 9877 # 增加这一个配置
+}
+
+```
+如果不配置端口，使用grpc客户端发送消息会失败
+
+检查grpc端口是否正常开启， 如下就是开启状态
+```sh 
+[root@localhost rocketmq514]# telnet localhost 9877
+Trying ::1...
+Connected to localhost.
+Escape character is '^]'.
+
+
+```
+
+### 启动broker
 $ nohup sh bin/mqbroker -n localhost:9876 --enable-proxy &
 
 ### 验证broker是否启动成功, 比如, broker的ip是192.168.1.2 然后名字是broker-a


### PR DESCRIPTION
通过grpc客户端demo发送数据到rocketmq5.x需要配置grpc端口，注意client端代码要使用grpc的地址和端口作为access_point参数

This pull request aims to address the need for configuring gRPC ports when sending data to RocketMQ using the gRPC client demo. The PR highlights that clients must use the gRPC server's address and port as the access_point parameter in their code.