### PR TITLE
Update 01quickstart.md

### DIFF
--- a/docs/01-quickstart/01quickstart.md
+++ b/docs/01-quickstart/01quickstart.md
@@ -55,7 +55,7 @@ NameServer成功启动后，我们启动Broker
 $ nohup sh bin/mqbroker -n localhost:9876 &
 
 ### 验证broker是否启动成功, 比如, broker的ip是192.168.1.2 然后名字是broker-a
-$ tail -f ~/logs/rocketmqlogs/Broker.log 
+$ tail -f ~/logs/rocketmqlogs/broker.log 
 The broker[broker-a,192.169.1.2:10911] boot success...
 ```
 


### PR DESCRIPTION
Fix: broker log file is lower case

Hi, I found the official docs has a error, so I fix it, the name of  broker log file is error

## What is the purpose of the change

the broker log file is not ~/logs/rocketmqlogs/Broker.log  ,the right command is tail -f  ~/logs/rocketmqlogs/broker.log

## Brief changelog

fix the log file name

## Verifying this change

```shell
tail -f ~/logs/rocketmqlogs/broker.log 
```

