### PR TITLE
Fix doc typo since message type validation is disabled by default.

### DIFF
--- a/i18n/en/docusaurus-plugin-content-docs/version-5.0/01-introduction/02concepts.md
+++ b/i18n/en/docusaurus-plugin-content-docs/version-5.0/01-introduction/02concepts.md
@@ -11,7 +11,7 @@ Categories defined by message transfer characteristics for type management and s
 
 :::info
 
-Starting from version 5.0, Apache RocketMQ supports enforcing the validation of message types, that is, each topic only allows messages of a single type to be sent. This can better facilitate operation and management of production systems and avoid confusion. However, to ensure backward compatibility with version 4.x, the validation feature is enable by default.
+Starting from version 5.0, Apache RocketMQ supports enforcing the validation of message types, that is, each topic only allows messages of a single type to be sent. This can better facilitate operation and management of production systems and avoid confusion. However, to ensure backward compatibility with version 4.x, the validation feature is disabled by default.
 :::
 
 ## MessageQueue

--- a/i18n/en/docusaurus-plugin-content-docs/version-5.0/03-domainModel/02topic.md
+++ b/i18n/en/docusaurus-plugin-content-docs/version-5.0/03-domainModel/02topic.md
@@ -59,7 +59,7 @@ A topic contains one or more queues. Message storage and scalability are impleme
 
   * Transaction: [Transaction messages](../04-featureBehavior/04transactionmessage.md). Apache RocketMQ supports distributed transaction messages and ensures transaction consistency of database updates and message calls.
 
-* Constraint: Starting from version 5.0, Apache RocketMQ supports enforcing the validation of message types, that is, each topic only allows messages of a single type to be sent. This can better facilitate operation and management of production systems and avoid confusion. However, to ensure backward compatibility with version 4.x, the validation feature is enable by default.
+* Constraint: Starting from version 5.0, Apache RocketMQ supports enforcing the validation of message types, that is, each topic only allows messages of a single type to be sent. This can better facilitate operation and management of production systems and avoid confusion. However, to ensure backward compatibility with version 4.x, the validation feature is disabled by default.
 
 
 ## Behavior constraints


### PR DESCRIPTION
Please do not create a Pull Request without creating an issue first. 

## What is the purpose of the change

fix doc typo. 

## Brief changelog

message type validation is added in v5.0, it is disabled by default to ensure pre v5.0 compatibility.

## Verifying this change

N/A

Follow this checklist to help us incorporate your contribution quickly and easily:

N/A
