### PR TITLE
Fix: Added missing NameServer parameter for RocketMQ Dashboard deployment

### DIFF
--- a/docs/04-deployment/03Dashboard.md
+++ b/docs/04-deployment/03Dashboard.md
@@ -3,6 +3,13 @@
 
 `RocketMQ Dashboard` 是 RocketMQ 的管控利器，为用户提供客户端和应用程序的各种事件、性能的统计信息，支持以可视化工具代替 Topic 配置、Broker 管理等命令行操作。
 
+### 启动 RocketMQ Dashboard
+
+使用以下命令启动 RocketMQ Dashboard：
+
+```bash
+java -jar rocketmq-dashboard-*.jar --rocketmq.config.namesrvAddr=localhost:9876
+
 ## 介绍
 
 ### 功能概览


### PR DESCRIPTION
This PR addresses an issue where the RocketMQ Dashboard fails with a connection null error due to a missing 
--rocketmq.config.namesrvAddr parameter in the deployment instructions.

Changes Made:

- Updated docs/04-deployment/03Dashboard.md to include the correct NameServer address parameter.
- Provided a clear example for running the Dashboard successfully.

Why This Fix?
- Without explicitly specifying the NameServer address, users following the documentation may encounter connection errors, 
   leading to deployment failures. This update ensures a smoother setup experience.

Fixes #680 