### PR TITLE
[ISSUE #744] Fix capitalization of 'DELAY' in message type attribute example

### DIFF
--- a/i18n/en/docusaurus-plugin-content-docs/version-5.0/04-featureBehavior/02delaymessage.md
+++ b/i18n/en/docusaurus-plugin-content-docs/version-5.0/04-featureBehavior/02delaymessage.md
@@ -97,7 +97,7 @@ The status of delay messages in Apache RocketMQ can be persistently stored. If t
 For creating topics in Apache RocketMQ 5.0, it is recommended to use the mqadmin tool. However, it is worth noting that message type needs to be added as a property parameter. Here is an example:
 
 ```shell
-sh mqadmin updateTopic -n <nameserver_address> -t <topic_name> -c <cluster_name> -a +message.type=Delay
+sh mqadmin updateTopic -n <nameserver_address> -t <topic_name> -c <cluster_name> -a +message.type=DELAY
 ```
 
 **Send messages**


### PR DESCRIPTION
## What is the purpose of the change

Fix a typo in the delay message documentation where the message type attribute is inconsistently capitalized. This ensures consistent documentation and examples throughout the site.

## Brief changelog

- Fixed capitalization of 'DELAY' in message type attribute example in the delay message documentation file (`/i18n/en/docusaurus-plugin-content-docs/version-5.0/04-featureBehavior/02delaymessage.md`)

## Issue reference

Fixes https://github.com/apache/rocketmq-site/issues/744

## Verifying this change

The change can be verified by checking that the message type attribute is consistently shown as 'DELAY' in uppercase in all examples in the documentation.

Follow this checklist to help us incorporate your contribution quickly and easily:

- [x] Make sure there is a Github issue filed for the change (usually before you start working on it). Trivial changes like typos do not require a Github issue. This PR addresses a typo fix, so no separate issue was created.
- [x] Format the pull request title appropriately. For typo fixes, the issue number is not required. Each commit in the pull request has a meaningful subject line and body.
- [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [ ] Write necessary unit-test to verify your logic correction, more mock a little better when cross module dependency exist. If the new feature or significant change is committed, please remember to add integration-test in [test module](https://github.com/apache/rocketmq/tree/master/test).
- [ ] Run `mvn -B clean apache-rat:check findbugs:findbugs checkstyle:checkstyle` to make sure basic checks pass. Run `mvn clean install -DskipITs` to make sure unit-test pass. Run `mvn clean test-compile failsafe:integration-test`  to make sure integration-test pass.
- [ ] If this contribution is large, please file an [Apache Individual Contributor License Agreement](http://www.apache.org/licenses/#clas).
