### PR TITLE
fix: Add required ASF policy links to footer

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -470,6 +470,18 @@ const darkCodeTheme = require("prism-react-renderer/themes/dracula");
                   label: 'Sponsorship',
                   href: 'https://www.apache.org/foundation/sponsorship.html',
                 },
+                {
+                  label: 'Privacy',
+                  href: 'https://privacy.apache.org/policies/privacy-policy-public.html',
+                },
+                {
+                  label: 'Events',
+                  href: 'https://www.apache.org/events/current-event.html',
+                },
+                {
+                  label: 'Foundation',
+                  href: 'https://www.apache.org/',
+                },
               ],
             },
           ],
@@ -478,7 +490,7 @@ const darkCodeTheme = require("prism-react-renderer/themes/dracula");
             src: 'img/Apache_RocketMQ_logo.svg.png',
             href: 'https://rocketmq.apache.org/',
           },
-          copyright: `Copyright © ${new Date().getFullYear()} The Apache Software Foundation. Licensed under the Apache License, Version 2.0.`,
+          copyright: `Copyright © ${new Date().getFullYear()} The Apache Software Foundation. Licensed under the Apache License, Version 2.0. Apache RocketMQ, RocketMQ, Apache, the Apache logo, and the Apache RocketMQ project logo are either registered trademarks or trademarks of The Apache Software Foundation.`,
         },
         prism: {
           theme: lightCodeTheme,


### PR DESCRIPTION
fix: Add required ASF policy links to footer

The RocketMQ website is failing 5 of 9 ASF website policy checks
(https://whimsy.apache.org/site/):

- Foundation link (missing)
- Events (missing)
- Trademarks (missing)
- Privacy (missing)
- License (was present but scanner may not have found it)

This adds Privacy, Events, and Foundation links to the existing
Legal section in the Docusaurus footer, and adds trademark
attribution to the copyright line.

See: https://www.apache.org/foundation/marks/pmcs
Checker: https://whimsy.apache.org/site/