### PR TITLE
docs: fix delay message type casing

### DIFF
--- a/i18n/en/docusaurus-plugin-content-docs/version-5.0/04-featureBehavior/02delaymessage.md
+++ b/i18n/en/docusaurus-plugin-content-docs/version-5.0/04-featureBehavior/02delaymessage.md
@@ -97,7 +97,7 @@ The status of delay messages in Apache RocketMQ can be persistently stored. If t
 For creating topics in Apache RocketMQ 5.0, it is recommended to use the mqadmin tool. However, it is worth noting that message type needs to be added as a property parameter. Here is an example:
 
 ```shell
-sh mqadmin updateTopic -n <nameserver_address> -t <topic_name> -c <cluster_name> -a +message.type=Delay
+sh mqadmin updateTopic -n <nameserver_address> -t <topic_name> -c <cluster_name> -a +message.type=DELAY
 ```
 
 **Send messages**


### PR DESCRIPTION
## Summary
- Update the delay message topic creation example to use `+message.type=DELAY`.
- This makes the example consistent with the later mqadmin example on the same page.

Fixes #744.

## Testing
- `rg -n "message\.type=Delay|message\.type=DELAY" i18n\en\docusaurus-plugin-content-docs\version-5.0\04-featureBehavior\02delaymessage.md`
- `git diff --check`

## AI disclosure
This pull request was prepared with assistance from OpenAI Codex.