### PR TITLE
docs: fix message filter spacing typo

### DIFF
--- a/i18n/en/docusaurus-plugin-content-docs/version-5.0/04-featureBehavior/07messagefilter.md
+++ b/i18n/en/docusaurus-plugin-content-docs/version-5.0/04-featureBehavior/07messagefilter.md
@@ -147,7 +147,7 @@ Tag-based filtering implements precise filtering based on character strings. You
 
 ## Attribute-based SQL filtering
 
-Attribute-based SQL filtering is an advanced message filtering method provided byApache RocketMQ. It filters messages based on the attributes and attribute values, which are also called keys and values, that producers configure for messages. Producers can set multiple attributes for a message. Consumers can then specify attributes in SQL expressions to receive certain messages.
+Attribute-based SQL filtering is an advanced message filtering method provided by Apache RocketMQ. It filters messages based on the attributes and attribute values, which are also called keys and values, that producers configure for messages. Producers can set multiple attributes for a message. Consumers can then specify attributes in SQL expressions to receive certain messages.
 
 :::info
 Because tags are a system attribute, tag-based filtering is a type of attribute-based SQL filtering. In SQL syntaxes, the tag attribute is represented by TAGS.


### PR DESCRIPTION
## Summary
- Add the missing space in `provided by Apache RocketMQ` in the message filtering documentation.

Fixes #742.

## Testing
- `rg -n "byApache|provided by Apache RocketMQ" i18n\en\docusaurus-plugin-content-docs\version-5.0\04-featureBehavior\07messagefilter.md`
- `git diff --check`

## AI disclosure
This pull request was prepared with assistance from OpenAI Codex.